### PR TITLE
React-Query 적용 및 리팩토링

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,6 @@
 import { BrowserRouter, Routes, Route } from 'react-router-dom';
 import './index.css';
+import { QueryClientProvider, QueryClient } from 'react-query';
 import ScheduleDetailPage from '@pages/schedule/getScheduleDetail';
 import ScheduleUpdatePage from '@pages/schedule/updateSchedule';
 import CreateCounseling from '@pages/counseling/createCounseling';
@@ -26,39 +27,43 @@ import MyPage from '@pages/myPage';
 import SearchResults from '@components/common/SearchResults';
 import LoginRouter from '@pages/auth/LoginRouter';
 
+const queryClient = new QueryClient();
+
 function App() {
   return (
-    <BrowserRouter>
-      <Layout>
-        <Routes>
-          <Route element={<LoginRouter />}>
-            <Route path="/" element={<Home />} />
-            <Route path="/schedule/personal/:scheduleId" element={<ScheduleDetailPage />} />
-            <Route path="/schedule" element={<Schedule />} />
-            <Route path="/schedules" element={<ScheduleApi />} />
-            <Route path="/schedule/personal/edit/:scheduleId" element={<ScheduleUpdatePage />} />
-            <Route path="/schedules/counseling/update/:scheduleId" element={<UpdateCounseling />} />
-            <Route path="/schedules/counseling/:scheduleId" element={<GetCounselingDetail />} />
-            <Route path="/schedules/counseling/new" element={<CreateCounseling />} />
-            <Route path="/tickets/centerTicket" element={<CenterTicketPage />} />
-            <Route path="/tickets/centerTicket/new" element={<CreateTicketPage />} />
-            <Route path="/schedule/privateLesson/new" element={<CreatePrivateLesson />} />
-            <Route path="/schedule/privateLesson/new/searchPeople" element={<SearchPeople />} />
-            <Route path="/members" element={<GetMembers />} />
-            <Route path="/members/new" element={<CreateMembers />} />
-            <Route path="/members/new/register" element={<RegisterMembers />} />
-            <Route path="/members/update/:memberId" element={<UpdateMembers />} />
-            <Route path="/members/:memberId" element={<GetMembersDetail />} />
-            <Route path="/members/:memberId/issued-tickets" element={<IssuedTicketPage />} />
-            <Route path="/tickets" element={<TicketListPage />} />
-            <Route path="/tickets/:ticketId" element={<IssuedTicketDetail />} />
-            <Route path="/staffs" element={<ShowStaffs />} />
-            <Route path="/myPage" element={<MyPage />} />
-            <Route path="/search-results" element={<SearchResults />} />
-          </Route>
-        </Routes>
-      </Layout>
-    </BrowserRouter>
+    <QueryClientProvider client={queryClient}>
+      <BrowserRouter>
+        <Layout>
+          <Routes>
+            <Route element={<LoginRouter />}>
+              <Route path="/" element={<Home />} />
+              <Route path="/schedule/personal/:scheduleId" element={<ScheduleDetailPage />} />
+              <Route path="/schedule" element={<Schedule />} />
+              <Route path="/schedules" element={<ScheduleApi />} />
+              <Route path="/schedule/personal/edit/:scheduleId" element={<ScheduleUpdatePage />} />
+              <Route path="/schedules/counseling/update/:scheduleId" element={<UpdateCounseling />} />
+              <Route path="/schedules/counseling/:scheduleId" element={<GetCounselingDetail />} />
+              <Route path="/schedules/counseling/new" element={<CreateCounseling />} />
+              <Route path="/tickets/centerTicket" element={<CenterTicketPage />} />
+              <Route path="/tickets/centerTicket/new" element={<CreateTicketPage />} />
+              <Route path="/schedule/privateLesson/new" element={<CreatePrivateLesson />} />
+              <Route path="/schedule/privateLesson/new/searchPeople" element={<SearchPeople />} />
+              <Route path="/members" element={<GetMembers />} />
+              <Route path="/members/new" element={<CreateMembers />} />
+              <Route path="/members/new/register" element={<RegisterMembers />} />
+              <Route path="/members/update/:memberId" element={<UpdateMembers />} />
+              <Route path="/members/:memberId" element={<GetMembersDetail />} />
+              <Route path="/members/:memberId/issued-tickets" element={<IssuedTicketPage />} />
+              <Route path="/tickets" element={<TicketListPage />} />
+              <Route path="/tickets/:ticketId" element={<IssuedTicketDetail />} />
+              <Route path="/staffs" element={<ShowStaffs />} />
+              <Route path="/myPage" element={<MyPage />} />
+              <Route path="/search-results" element={<SearchResults />} />
+            </Route>
+          </Routes>
+        </Layout>
+      </BrowserRouter>
+    </QueryClientProvider>
   );
 }
 

--- a/src/components/common/Modal/Modal.tsx
+++ b/src/components/common/Modal/Modal.tsx
@@ -7,9 +7,18 @@ interface ModalProps {
   onConfirm: () => void;
   width?: string;
   isDisabled?: boolean;
+  onlyConfirm?: boolean;
 }
 
-const Modal: React.FC<ModalProps> = ({ isOpen, content, onClose, onConfirm, width, isDisabled = false }) => {
+const Modal: React.FC<ModalProps> = ({
+  isOpen,
+  content,
+  onClose,
+  onConfirm,
+  width,
+  isDisabled = false,
+  onlyConfirm = false,
+}) => {
   if (!isOpen) {
     return null;
   }
@@ -40,9 +49,11 @@ const Modal: React.FC<ModalProps> = ({ isOpen, content, onClose, onConfirm, widt
       <div className="p-10 bg-white rounded shadow-md" onClick={stopPropagation}>
         {content}
         <div className="flex justify-end mt-4">
-          <button className={`${width} px-4 py-2 mr-2 bg-gray-300 rounded`} onClick={onClose} type="button">
-            취소
-          </button>
+          {!onlyConfirm && (
+            <button className={`${width} px-4 py-2 mr-2 bg-gray-300 rounded`} onClick={onClose} type="button">
+              취소
+            </button>
+          )}
           <button
             className={`${width} px-4 py-2 ${isDisabled ? 'bg-gray-300' : 'text-white bg-blue-500'} rounded`}
             onClick={handleConfirm}

--- a/src/components/common/Modal/Modal.tsx
+++ b/src/components/common/Modal/Modal.tsx
@@ -40,7 +40,7 @@ const Modal: React.FC<ModalProps> = ({
 
   return (
     <div
-      className="fixed inset-0 flex items-center justify-center bg-black bg-opacity-50"
+      className="fixed inset-0 z-10 flex items-center justify-center bg-black bg-opacity-50"
       role="button"
       onClick={onClose}
       onKeyDown={handleKeyDown}

--- a/src/pages/members/components/AgreeCondition.tsx
+++ b/src/pages/members/components/AgreeCondition.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import Modal from '@components/common/Modal/Modal';
 
 interface AgreeConditonProps {
   title: string;
@@ -8,6 +9,8 @@ interface AgreeConditonProps {
 
 const AgreeCondition = ({ title, defaultState, onChange }: AgreeConditonProps) => {
   const [state, setState] = useState<boolean>(defaultState || false);
+  const [showModal, setShowModal] = useState(false);
+
   const handleAgreementChange = () => {
     const newState = !state;
     setState(newState);
@@ -15,7 +18,11 @@ const AgreeCondition = ({ title, defaultState, onChange }: AgreeConditonProps) =
   };
 
   const viewTerms = () => {
-    alert('약관');
+    setShowModal(true);
+  };
+
+  const closeTermsModal = () => {
+    setShowModal(false);
   };
 
   return (
@@ -38,6 +45,39 @@ const AgreeCondition = ({ title, defaultState, onChange }: AgreeConditonProps) =
           약관보기
         </button>
       </div>
+      <Modal
+        isOpen={showModal}
+        content={
+          <div className="w-96">
+            <h1 className="flex justify-center mb-5 text-lg font-bold">포인티 이용약관(필수)</h1>
+            <div className="overflow-y-auto max-h-[496px]">
+              <h2 className="mb-5 text-lg font-bold">총칙</h2>
+              <div className="mb-5">
+                <h3 className="font-bold text-md">제1조 [목적]</h3>
+                <p>
+                  이 약관은 주식회사 파이헬스케어(이하 ‘포인티'라 함)가 운영하는 CRM 서비스에서 제공하는 전자 서비스
+                  이용 관련 서비스(이하 ‘서비스'라 함)를 이용함에 있어 포인티와 이용자의 권리, 의무 및 책임사항을
+                  규정함을 목적으로 합니다. PC통신, 스마트폰 앱, 무선 등을 이용하는 전자상거래에 대해서도 그 성질에
+                  반하지 않는한 이 약관을 준용합니다.
+                </p>
+              </div>
+              <div className="mb-5">
+                <h3 className="font-bold text-md">제2조 [정의]</h3>
+                <p>
+                  이 약관은 주식회사 파이헬스케어(이하 ‘포인티'라 함)가 운영하는 CRM 서비스에서 제공하는 전자 서비스
+                  이용 관련 서비스(이하 ‘서비스'라 함)를 이용함에 있어 포인티와 이용자의 권리, 의무 및 책임사항을
+                  규정함을 목적으로 합니다. PC통신, 스마트폰 앱, 무선 등을 이용하는 전자상거래에 대해서도 그 성질에
+                  반하지 않는한 이 약관을 준용합니다.
+                </p>
+              </div>
+            </div>
+          </div>
+        }
+        onClose={closeTermsModal}
+        onConfirm={closeTermsModal}
+        onlyConfirm={true}
+        width="w-full"
+      />
     </div>
   );
 };

--- a/src/pages/members/getMembers.tsx
+++ b/src/pages/members/getMembers.tsx
@@ -1,4 +1,5 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState } from 'react';
+import { useQuery } from 'react-query';
 import { useNavigate } from 'react-router-dom';
 import { axiosInstance } from '@/utils/apiInstance';
 import { Member } from '@/types/members/members';
@@ -7,47 +8,38 @@ import MembersItem from '@pages/members/components/MembersItem';
 import { ReactComponent as Search } from '@/assets/icons/Search.svg';
 
 const GetMembers = () => {
-  const [memberList, setMemberList] = useState<Member[] | null>(null);
   const [searchQuery, setSearchQuery] = useState('');
   const [currentPage, setCurrentPage] = useState(1);
   const membersPerPage = 10;
   const navigate = useNavigate();
-  const [metaData, setMetaData] = useState({
-    totalCount: 0,
-    size: 0,
-    count: 0,
-    page: 0,
-    hasMore: true,
-  });
 
-  const getMembers = async (page: number) => {
-    const res = await axiosInstance.get('members', {
-      params: {
-        page,
-        size: membersPerPage,
-        sort: 'createdAt,Asc',
-      },
-    });
-    setMemberList(res.data.datas);
-    setMetaData(res.data.meta);
-  };
+  const { data, isLoading } = useQuery(
+    ['members', currentPage],
+    async () => {
+      const res = await axiosInstance.get('members', {
+        params: {
+          page: currentPage,
+          size: membersPerPage,
+          sort: 'createdAt,Asc',
+        },
+      });
+      return res.data;
+    },
+    {
+      keepPreviousData: true,
+    },
+  );
+  const displayedMembers = searchQuery
+    ? data?.datas.filter((member: Member) => member.name.includes(searchQuery) || member.phone.includes(searchQuery))
+    : data?.datas || [];
 
-  useEffect(() => {
-    getMembers(currentPage);
-  }, [currentPage]);
-
-  // 검색 (이름 or 전화번호)
-  let displayedMembers = memberList || [];
-  if (searchQuery) {
-    displayedMembers = displayedMembers.filter(
-      (data) => data.name.includes(searchQuery) || data.phone.includes(searchQuery),
-    );
-  }
+  const totalPages = Math.ceil(data?.meta.totalCount / membersPerPage);
 
   const goCreateMembers = () => {
     navigate('/members/new');
   };
 
+  if (isLoading) return <div>loading...</div>;
   return (
     <div className="p-5 bg-bg-100">
       <div className="flex w-1/3 overflow-hidden bg-white border rounded-xl">
@@ -66,7 +58,7 @@ const GetMembers = () => {
       <div className="flex justify-between my-3 font-bold">
         <div className="flex items-center justify-center">
           <h1 className="mr-2">나의 회원</h1>
-          <p className="text-primary-500">{metaData.totalCount}</p>
+          <p className="text-primary-500">{data?.meta.totalCount}</p>
         </div>
         <button
           className="px-2 py-1 bg-white border-2 border-solid border-line-300 rounded-xl"
@@ -78,14 +70,14 @@ const GetMembers = () => {
 
       <ul className="flex flex-col">
         {displayedMembers && displayedMembers.length > 0 ? (
-          displayedMembers.map((members) => <MembersItem key={members.id} members={members} />)
+          displayedMembers.map((member: Member) => <MembersItem key={member.id} members={member} />)
         ) : (
           <NoMembers />
         )}
       </ul>
 
       <div className="flex justify-center mt-4">
-        {Array.from({ length: Math.ceil(metaData.totalCount / membersPerPage) }, (_, index) => (
+        {Array.from({ length: totalPages }, (_, index) => (
           <button
             key={index}
             className={`px-3 py-1 m-2 rounded ${currentPage === index + 1 ? 'bg-primary-500 text-white' : 'bg-white'}`}

--- a/src/pages/members/getMembersDetail.tsx
+++ b/src/pages/members/getMembersDetail.tsx
@@ -1,5 +1,6 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
+import { useQuery } from 'react-query';
 import { axiosInstance } from '@/utils/apiInstance';
 import SubHeader from '@components/common/SubHeader';
 import { ReactComponent as MoreVert } from '@/assets/icons/MoreVert.svg';
@@ -10,7 +11,6 @@ import { ReactComponent as Edit } from '@/assets/icons/Edit.svg';
 import MemberRecord from '@pages/members/components/MemberRecord';
 import MemberReview from '@pages/members/components/MemberReview';
 import MemberAlbum from '@pages/members/components/MemberAlbum';
-import { MembersDetail } from '@/types/members/membersDetail';
 
 type TabType = 'record' | 'review' | 'album';
 
@@ -19,23 +19,20 @@ const GetMembersDetail = () => {
   const { memberId } = useParams<{ memberId: string | undefined }>();
   const navigate = useNavigate();
 
-  const goMainMembers = () => {
-    navigate(`/members/${memberId}/issued-tickets`);
-  };
+  const goMainMembers = () => navigate(`/members/${memberId}/issued-tickets`);
+  const goUpdateMembers = () => navigate(`/members/update/${memberId}`);
 
-  const goUpdateMembers = () => {
-    navigate(`/members/update/${memberId}`);
-  };
-
-  const [memberDetail, setMemberDetail] = useState<MembersDetail | null>(null);
-  const getMemberDatail = async () => {
-    const res = await axiosInstance.get(`members/${memberId}`);
-    setMemberDetail(res.data);
-  };
-
-  useEffect(() => {
-    getMemberDatail();
-  }, []);
+  const { data: memberDetail, isLoading } = useQuery(
+    [`members`, memberId],
+    async () => {
+      if (!memberId) return null;
+      const res = await axiosInstance.get(`members/${memberId}`);
+      return res.data;
+    },
+    {
+      enabled: !!memberId,
+    },
+  );
 
   const memberInformation = [
     { id: 1, label: '이름', value: memberDetail?.name },
@@ -45,6 +42,14 @@ const GetMembersDetail = () => {
     { id: 5, label: '전화번호', value: memberDetail?.phone },
     { id: 6, label: '직업형태', value: memberDetail?.job },
   ];
+
+  const TabComponents = {
+    record: <MemberRecord />,
+    review: <MemberReview />,
+    album: <MemberAlbum />,
+  };
+
+  if (isLoading) return <div>loading...</div>;
 
   return (
     <>
@@ -105,9 +110,7 @@ const GetMembersDetail = () => {
           </button>
         </div>
 
-        {activeTab === 'record' && <MemberRecord />}
-        {activeTab === 'review' && <MemberReview />}
-        {activeTab === 'album' && <MemberAlbum />}
+        {TabComponents[activeTab]}
       </section>
     </>
   );

--- a/src/pages/members/registerMembers.tsx
+++ b/src/pages/members/registerMembers.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React from 'react';
 import { useNavigate, useLocation } from 'react-router-dom';
 import register from '@/assets/images/Graphic_Member_registered.png';
 import { ReactComponent as Close } from '@/assets/icons/Close.svg';
@@ -8,9 +8,8 @@ const RegisterMembers = () => {
   const memberName = location.state?.memberName || '';
   const navigate = useNavigate();
 
-  const goMainMembers = () => {
-    navigate('/members');
-  };
+  const goMainMembers = () => navigate('/members');
+
   return (
     <div className="flex flex-col items-center">
       <div className="flex justify-end w-full mt-4 mb-4">


### PR DESCRIPTION
## 작업 내용
- Modal 컴포넌트 확인 버튼 하나만 있는 경우 추가

#### 회원 관리

- 회원 생성 (createMembers)
  - useMutation 적용
  - onChange, handleInputChange 함수 제거하고 handleChange에 통합
  - 완료 버튼 활성화 조건에 약관 동의 포함

- 회원 조회 (getMembers)
  - useQuery 적용
  - 검색과 페이지네이션 분리

- 회원 상세 조회 (getMembersDetail)
  - useQuery 적용
  - activeTab에 따른 컴포넌트 렌더링 부분을 조건부 렌더링으로 수정

- 회원 정보 변경 (updateMembers)
  - useQuery 적용
  - useMutation 적용
  - onChange, handleInputChange, numberChange 함수 제거하고 handleChange에 통합


#### 상담 일정 관리

- 상담 일정 생성 (createCounseling)
  - useMutation 적용
  - 불필요한 recoil 사용 취소 (timeList만 recoil적용)
 
- 상담 일정 조회 (schedulApi)
  - useQuery 적용

- 상담 상세 일정 조회 및 취소 (getCounselingDetail)
  - useQuery 적용
  - useMutation 적용
  - 불필요한 useRecoilState 제거
  - 문자열 파싱 함수 생성하여 코드 간소화

- 상담 일정 변경 (updateCounseling)
  - useQuery 적용
  - useMutation 적용
  - numberChange, onDateChange 함수 제거하고 handleChange에 통합

- 상담 기록 (CounselingScheduleDetail)
  - useQuery 적용
  - useMutation 적용
  - 구조 분해 할당으로 itemData 참조
  - 반복되는 버튼 스타일을 상수로 분리

closed #171 